### PR TITLE
New bitstream API

### DIFF
--- a/src/SharpAV1/AomStream.cs
+++ b/src/SharpAV1/AomStream.cs
@@ -8,20 +8,20 @@ namespace SharpAV1
 {
     public class AomStream : IDisposable
     {
-        private int _bitsPosition;
-        private int _currentBytePosition = -1;
-        private byte _currentByte = 0;
-
-        private readonly Stream _stream;
-
         private bool _disposedValue;
 
         public IMp4Logger Logger { get; set; }
+        public Bitstream Bitstream { get; set; }
+
+        public AomStream(Bitstream bitstream, IMp4Logger logger)
+        {
+            this.Bitstream = bitstream;
+            this.Logger = logger ?? new DefaultMp4Logger();
+        }
 
         public AomStream(Stream stream, IMp4Logger logger)
+            : this(new Bitstream(stream), logger)
         {
-            this._stream = stream ?? new MemoryStream();
-            this.Logger = logger ?? new DefaultMp4Logger();
         }
 
         public AomStream(Stream stream)
@@ -29,56 +29,31 @@ namespace SharpAV1
         {
         }
 
+        // TODO: support long for GetPosition()?
         public int GetPosition()
         {
-            return _bitsPosition;
+            return (int)this.Bitstream.BitsPosition;
         }
 
         public void Skip(long bits)
         {
-            while (_bitsPosition % 8 != 0)
+            while (this.Bitstream.BitsPosition % 8 != 0)
             {
                 ReadBit();
                 bits--;
             }
 
-            _bitsPosition += (int)bits;
+            this.Bitstream.BitsPosition += bits;
 
             long bytes = (bits >> 3);
-            _stream.Seek(bytes, SeekOrigin.Current);
+            this.Bitstream.BaseStream.Seek(bytes, SeekOrigin.Current);
         }
 
         #region Bit read/write
 
-        private int ReadByte()
-        {
-            int ret = _stream.ReadByte();
-            return ret;
-        }
+        private int ReadByte() => this.Bitstream.BaseStream.ReadByte();
 
-        private int ReadBit()
-        {
-            int bytePos = _bitsPosition / 8;
-
-            if (_currentBytePosition != bytePos)
-            {
-                int bb = ReadByte();
-                if (bb == -1)
-                {
-                    return -1;
-                }
-
-                byte b = (byte)bb;
-
-                _currentByte = b;
-                _currentBytePosition = bytePos;
-            }
-
-            int posInByte = 7 - _bitsPosition % 8;
-            int bit = _currentByte >> posInByte & 1;
-            ++_bitsPosition;
-            return bit;
-        }
+        private int ReadBit() => this.Bitstream.ReadBit();
 
         private long ReadBits(int count)
         {
@@ -88,7 +63,7 @@ namespace SharpAV1
             long res = 0;
             while (count > 0)
             {
-                res = res << 1;
+                res <<= 1;
                 int u1 = ReadBit();
 
                 if (u1 == -1)
@@ -277,10 +252,7 @@ namespace SharpAV1
             {
                 if (disposing)
                 {
-                    if (_stream != null)
-                    {
-                        _stream.Dispose();
-                    }
+                    this.Bitstream.BaseStream.Dispose();
                 }
 
                 _disposedValue = true;

--- a/src/SharpH26X/ItuStream.cs
+++ b/src/SharpH26X/ItuStream.cs
@@ -10,13 +10,6 @@ namespace SharpH26X
 {
     public class ItuStream : IDisposable
     {
-        private readonly bool _shouldEscapeNals = true;
-        private int _bitsPosition;
-        private int _currentBytePosition = -1;
-        private byte _currentByte = 0;
-        private int _prevByte = -1;
-        private int _prevPrevByte = -1;
-
         private readonly Stream _stream;
 
         private int _rbspDataCounter = -1;
@@ -24,28 +17,25 @@ namespace SharpH26X
         private int _readNextBitsIndex = 0;
 
         private bool _disposedValue;
-        private int _lastMarkBeginPosition;
 
         public IMp4Logger Logger { get; set; }
+        public RbspBitstream Bitstream { get; set; }
+
+        public ItuStream(RbspBitstream bitstream, IMp4Logger logger)
+        {
+            this._stream = bitstream.BaseStream;
+            this.Logger = logger;
+            this.Bitstream = bitstream;
+        }
 
         public ItuStream(Stream stream, IMp4Logger logger)
+            : this(new RbspBitstream(stream), logger)
         {
-            this._stream = stream;
-            this.Logger = logger;
         }
 
         public ItuStream(Stream stream)
             : this(stream, new DefaultMp4Logger())
         {
-        }
-
-        public ItuStream(Stream stream, int bitsPosition, int currentBytePosition, byte currentByte, int prevByte, int prevPrevByte) : this(stream)
-        {
-            this._bitsPosition = bitsPosition;
-            this._currentBytePosition = currentBytePosition;
-            this._currentByte = currentByte;
-            this._prevByte = prevByte;
-            this._prevPrevByte = prevPrevByte;
         }
 
         #region Bit read/write
@@ -62,48 +52,7 @@ namespace SharpH26X
             return 8;
         }
 
-        private int ReadBit()
-        {
-            int bytePos = _bitsPosition / 8;
-
-            if (_currentBytePosition != bytePos)
-            {
-                int bb = ReadByte();
-                if (bb == -1)
-                {
-                    return -1;
-                }
-
-                byte b = (byte)bb;
-
-                // remove emulation prevention byte
-                if (_shouldEscapeNals && _prevByte == 0 && _currentByte == 0 && b == 0x03)
-                {
-                    _prevByte = b;
-                    bb = ReadByte();
-                    if (bb == -1)
-                    {
-                        return -1;
-                    }
-                    b = (byte)bb;
-                    _bitsPosition += 8;
-                    _lastMarkBeginPosition += 8; // compensate for emulation prevention bytes
-                    bytePos++;
-                }
-                else
-                {
-                    _prevByte = _currentByte;
-                }
-
-                _currentByte = b;
-                _currentBytePosition = bytePos;
-            }
-
-            int posInByte = 7 - _bitsPosition % 8;
-            int bit = _currentByte >> posInByte & 1;
-            ++_bitsPosition;
-            return bit;
-        }
+        private int ReadBit() => this.Bitstream.ReadBit();
 
         private long ReadBits(int count)
         {
@@ -126,44 +75,7 @@ namespace SharpH26X
             return res;
         }
 
-        public void WriteBit(int value)
-        {
-            int posInByte = 7 - (int)_bitsPosition % 8;
-            int bit = (value & 1) << posInByte;
-            _currentByte = (byte)(_currentByte | bit);
-            ++_bitsPosition;
-
-            int bytePos = _bitsPosition / 8;
-            if (_currentBytePosition != bytePos)
-            {
-                if (_currentBytePosition < 0)
-                {
-                    _currentBytePosition = bytePos;
-                    return;
-                }
-
-                if (_shouldEscapeNals)
-                {
-                    // write emulation prevention byte to properly escape sequences of 0x000000, 0x000001, 0x000002, 0x000003 into 0x00000300, 0x00000301, 0x00000302 and 0x00000303 respectively
-                    if (_prevByte == 0x00 && _prevPrevByte == 0x00 && (_currentByte == 0x00 || _currentByte == 0x01 || _currentByte == 0x02 || _currentByte == 0x03))
-                    {
-                        WriteByte(0x03);
-                        bytePos++;
-                        _bitsPosition += 8;
-                        _lastMarkBeginPosition += 8; // compensate for emulation prevention
-                        _prevByte = 0x03;
-                    }
-                }
-
-                WriteByte(_currentByte);
-                _currentBytePosition = bytePos;
-
-                _prevPrevByte = _prevByte;
-                _prevByte = _currentByte;
-
-                _currentByte = 0;
-            }
-        }
+        public void WriteBit(int value) => this.Bitstream.WriteBit(value);
 
         private void WriteBits(int count, ulong value)
         {
@@ -181,19 +93,13 @@ namespace SharpH26X
 
         #endregion // Bit read/write
 
-        public void MarkCurrentBitsPosition()
-        {
-            _lastMarkBeginPosition = _bitsPosition;
-        }
+        public void MarkCurrentBitsPosition() => this.Bitstream.Mark();
 
-        public ulong GetBitsPositionSinceLastMark()
-        {
-            return (ulong)(_bitsPosition - _lastMarkBeginPosition);
-        }
+        public ulong GetBitsPositionSinceLastMark() => (ulong)this.Bitstream.GetBitsSinceMark();
 
         public bool ByteAligned()
         {
-            return _bitsPosition % 8 == 0;
+            return this.Bitstream.BitsPosition % 8 == 0;
         }
 
         // H265
@@ -391,14 +297,19 @@ namespace SharpH26X
 
         public bool ReadMoreRbspData(IItuSerializable serializable, ulong maxPayloadSize = ulong.MaxValue)
         {
-            if (_stream.Position == _stream.Length && _bitsPosition % 8 == 0)
+            if (_stream.Position == _stream.Length && this.Bitstream.BitsPosition % 8 == 0)
                 return false;
 
             // now we have to look ahead - TODO
             var bytes = (_stream as MemoryStream).ToArray();
+
             var msstream = new MemoryStream(bytes);
             msstream.Seek(_stream.Position, SeekOrigin.Begin);
-            using (var ituStream = new ItuStream(msstream, _bitsPosition, _currentBytePosition, _currentByte, _prevByte, _prevPrevByte))
+
+            var newBitstream = new RbspBitstream(msstream);
+            newBitstream.CopyState(this.Bitstream);
+
+            using (var ituStream = new ItuStream(newBitstream, new DefaultMp4Logger()))
             {
                 int one = ituStream.ReadBit();
                 if (one == -1)
@@ -462,7 +373,11 @@ namespace SharpH26X
             var bytes = (_stream as MemoryStream).ToArray();
             var msstream = new MemoryStream(bytes);
             msstream.Seek(_stream.Position, SeekOrigin.Begin);
-            using (var ituStream = new ItuStream(msstream, _bitsPosition, _currentBytePosition, _currentByte, _prevByte, _prevPrevByte))
+
+            var newBitstream = new RbspBitstream(msstream);
+            newBitstream.CopyState(this.Bitstream);
+
+            using (var ituStream = new ItuStream(newBitstream, new DefaultMp4Logger()))
             {
                 if (serializable.ReadNextBits == null)
                 {

--- a/src/SharpISOBMFF/IStorage.cs
+++ b/src/SharpISOBMFF/IStorage.cs
@@ -113,4 +113,50 @@ namespace SharpISOBMFF
             return _stream.Read(buffer, offset, length);
         }
     }
+
+    internal class StorageStream(IStorage storage) : Stream
+    {
+        public override bool CanRead => true;
+
+        public override bool CanSeek => storage.CanStreamSeek();
+
+        public override bool CanWrite => true;
+
+        public override long Length => storage.GetLength();
+
+        public override long Position
+        {
+            get => storage.GetPosition();
+            set => storage.SeekFromBeginning(value);
+        }
+
+        public override void Flush()
+        {
+            storage.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return storage.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            origin switch
+            {
+                SeekOrigin.Begin => storage.SeekFromBeginning(offset),
+                SeekOrigin.Current => storage.SeekFromCurrent(offset),
+                SeekOrigin.End => storage.SeekFromEnd(offset),
+                _ => throw new ArgumentOutOfRangeException(nameof(origin))
+            };
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException("IStorage does not support modifying lengths");
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            storage.Write(buffer, offset, count);
+        }
+    }
 }

--- a/src/SharpISOBMFF/IsoStream.cs
+++ b/src/SharpISOBMFF/IsoStream.cs
@@ -9,7 +9,7 @@ namespace SharpISOBMFF
     public class IsoStream : IDisposable
     {
         protected readonly IStorage _stream;
-        private readonly Bitstream bitstream;
+        private Bitstream bitstream;
         private bool _disposedValue;
         private ITemporaryStorageFactory _storageFactory;
         private IsoStream _temp;
@@ -27,6 +27,12 @@ namespace SharpISOBMFF
 
             this.Logger = logger ?? new DefaultMp4Logger();
             this.bitstream = new(new StorageStream(stream));
+        }
+
+        public Bitstream Bitstream
+        {
+            get => this.bitstream;
+            set => this.bitstream = value;
         }
 
         // In case users would like to change it later, for example to use memory storage instead of file storage

--- a/src/SharpISOBMFF/IsoStream.cs
+++ b/src/SharpISOBMFF/IsoStream.cs
@@ -9,9 +9,7 @@ namespace SharpISOBMFF
     public class IsoStream : IDisposable
     {
         protected readonly IStorage _stream;
-        protected int _bitsPosition;
-        protected int _currentBytePosition = -1;
-        protected byte _currentByte = 0;
+        private readonly Bitstream bitstream;
         private bool _disposedValue;
         private ITemporaryStorageFactory _storageFactory;
         private IsoStream _temp;
@@ -28,6 +26,7 @@ namespace SharpISOBMFF
             _storageFactory = storageFactory ?? new TemporaryFileStorageFactory();
 
             this.Logger = logger ?? new DefaultMp4Logger();
+            this.bitstream = new(new StorageStream(stream));
         }
 
         // In case users would like to change it later, for example to use memory storage instead of file storage
@@ -123,41 +122,9 @@ namespace SharpISOBMFF
 
         #region Basic read/write operations
 
-        private int ReadBitInternal()
-        {
-            int bytePos = _bitsPosition >> 3;
+        private int ReadBitInternal() => this.bitstream.ReadBit();
 
-            if (_currentBytePosition != bytePos)
-            {
-                byte b = ReadByte();
-                _currentByte = b;
-                _currentBytePosition = bytePos;
-            }
-
-            int posInByte = 7 - _bitsPosition % 8;
-            int bit = _currentByte >> posInByte & 1;
-            ++_bitsPosition;
-            return bit;
-        }
-
-        private void WriteBitInternal(int value)
-        {
-            int posInByte = 7 - _bitsPosition % 8;
-            int bit = (value & 1) << posInByte;
-            _currentByte = (byte)(_currentByte | bit);
-            ++_bitsPosition;
-
-            int bytePos = _bitsPosition >> 3;
-            if (_currentBytePosition != bytePos)
-            {
-                if (_currentBytePosition != -1) // special case for the first bit
-                {
-                    WriteByte(_currentByte);
-                    _currentByte = 0;
-                }
-                _currentBytePosition = bytePos;
-            }
-        }
+        private void WriteBitInternal(int value) => this.bitstream.WriteBit(value);
 
         public int ReadByteInternal()
         {
@@ -453,17 +420,17 @@ namespace SharpISOBMFF
 
         public ulong ReadByteAlignment(ulong boxSize, ulong readSize, out byte value, string name)
         {
-            int bytePos = _bitsPosition >> 3;
-            int currentBytePos = bytePos << 3;
-            uint bitsToRead = (uint)(8 - (_bitsPosition - currentBytePos));
+            long bytePos = this.bitstream.BitsPosition >> 3;
+            long currentBytePos = bytePos << 3;
+            uint bitsToRead = (uint)(8 - (this.bitstream.BitsPosition - currentBytePos));
             return ReadBits(boxSize, readSize, bitsToRead, out value, name);
         }
 
         public ulong WriteByteAlignment(byte value, string name)
         {
-            int bytePos = _bitsPosition >> 3;
-            int currentBytePos = bytePos << 3;
-            uint bitsToWrite = (uint)(8 - (_bitsPosition - currentBytePos));
+            long bytePos = this.bitstream.BitsPosition >> 3;
+            long currentBytePos = bytePos << 3;
+            uint bitsToWrite = (uint)(8 - (this.bitstream.BitsPosition - currentBytePos));
             return WriteBits(bitsToWrite, value, name);
         }
 

--- a/src/SharpMP4Common/Bitstream.cs
+++ b/src/SharpMP4Common/Bitstream.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.IO;
+
+namespace SharpMP4.Common
+{
+    public class Bitstream
+    {
+        private long _bitsPosition;
+        private long _currentBytePosition = -1;
+        private byte _currentByte;
+
+        private readonly Stream _stream;
+
+        public Bitstream(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public long BitsPosition
+        {
+            get => _bitsPosition;
+            set => _bitsPosition = value;
+        }
+
+        private int ReadBitInternal()
+        {
+            long bytePos = _bitsPosition >> 3;
+
+            if (_currentBytePosition != bytePos)
+            {
+                byte b = ReadByte();
+                _currentByte = b;
+                _currentBytePosition = bytePos;
+            }
+
+            long posInByte = 7 - _bitsPosition % 8;
+            int bit = _currentByte >> (int)posInByte & 1;
+            ++_bitsPosition;
+            return bit;
+        }
+
+        private void WriteBitInternal(int value)
+        {
+            long posInByte = 7 - _bitsPosition % 8;
+            int bit = (value & 1) << (int)posInByte;
+            _currentByte = (byte)(_currentByte | bit);
+            ++_bitsPosition;
+
+            long bytePos = _bitsPosition >> 3;
+            if (_currentBytePosition != bytePos)
+            {
+                if (_currentBytePosition != -1) // special case for the first bit
+                {
+                    WriteByte(_currentByte);
+                    _currentByte = 0;
+                }
+                _currentBytePosition = bytePos;
+            }
+        }
+
+        public int ReadBit() => ReadBitInternal();
+        public void WriteBit(int bit) => WriteBitInternal(bit);
+
+        private int ReadByteInternal()
+        {
+            return _stream.ReadByte();
+        }
+
+        public byte ReadByte()
+        {
+            int read = ReadByteInternal();
+            if (read == -1) throw new EndOfStreamException();
+            return (byte)(read & 0xff);
+        }
+
+        public ulong WriteByte(byte value)
+        {
+            _stream.WriteByte(value);
+            return 8;
+        }
+
+        public ulong ReadBits(uint count, out uint value)
+        {
+            if (count > 32)
+                throw new ArgumentException("'count' cannot be greater than 32", nameof(count));
+
+            uint originalCount = count;
+            int res = 0;
+
+            while (count > 0)
+            {
+                res <<= 1;
+                int u1 = ReadBitInternal();
+
+                if (u1 == -1)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                res |= u1;
+                count--;
+            }
+
+            value = (uint)res;
+            return originalCount;
+        }
+
+        public uint ReadBits(uint count)
+        {
+            ReadBits(count, out uint value);
+            return value;
+        }
+
+        public ulong ReadBits(uint count, out ulong value)
+        {
+            if (count > 64)
+                throw new ArgumentException("'count' cannot be greater than 64", nameof(count));
+
+            uint originalCount = count;
+            long res = 0;
+            while (count > 0)
+            {
+                res <<= 1;
+                long u1 = ReadBitInternal();
+
+                if (u1 == -1)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                res |= u1;
+                count--;
+            }
+
+            value = (ulong)res;
+            return originalCount;
+        }
+
+        public ulong ReadBits(ulong count)
+        {
+            ReadBits((uint)count, out ulong value);
+            return value;
+        }
+
+        public ulong WriteBits(uint count, ulong value)
+        {
+            if (count > 64)
+                throw new ArgumentException("'count' cannot be greater than 64", nameof(count));
+
+            uint originalCount = count;
+            while (count > 0)
+            {
+                int bits = (int)count - 1;
+                ulong mask = 0x1u << bits;
+                WriteBitInternal((int)((value & mask) >> bits));
+                count--;
+            }
+
+            return originalCount;
+        }
+
+        public uint WriteBits(uint count, uint value)
+        {
+            if (count > 32)
+                throw new ArgumentException("'count' cannot be greater than 32", nameof(count));
+
+            uint originalCount = count;
+            while (count > 0)
+            {
+                int bits = (int)count - 1;
+                ulong mask = 0x1u << bits;
+                WriteBitInternal((int)((value & mask) >> bits));
+                count--;
+            }
+
+            return originalCount;
+        }
+    }
+}

--- a/src/SharpMP4Common/Bitstream.cs
+++ b/src/SharpMP4Common/Bitstream.cs
@@ -5,11 +5,11 @@ namespace SharpMP4.Common
 {
     public class Bitstream
     {
-        private long _bitsPosition;
-        private long _currentBytePosition = -1;
-        private byte _currentByte;
+        protected long _bitsPosition;
+        protected long _currentBytePosition = -1;
+        protected byte _currentByte;
 
-        private readonly Stream _stream;
+        protected Stream _stream;
 
         public Bitstream(Stream stream)
         {
@@ -20,6 +20,17 @@ namespace SharpMP4.Common
         {
             get => _bitsPosition;
             set => _bitsPosition = value;
+        }
+
+        public byte CurrentByte
+        {
+            get => _currentByte;
+            set => _currentByte = value;
+        }
+
+        public Stream BaseStream
+        {
+            get => _stream;
         }
 
         private int ReadBitInternal()
@@ -58,28 +69,28 @@ namespace SharpMP4.Common
             }
         }
 
-        public int ReadBit() => ReadBitInternal();
-        public void WriteBit(int bit) => WriteBitInternal(bit);
+        public virtual int ReadBit() => ReadBitInternal();
+        public virtual void WriteBit(int bit) => WriteBitInternal(bit);
 
         private int ReadByteInternal()
         {
             return _stream.ReadByte();
         }
 
-        public byte ReadByte()
+        public virtual byte ReadByte()
         {
             int read = ReadByteInternal();
             if (read == -1) throw new EndOfStreamException();
             return (byte)(read & 0xff);
         }
 
-        public ulong WriteByte(byte value)
+        public virtual ulong WriteByte(byte value)
         {
             _stream.WriteByte(value);
             return 8;
         }
 
-        public ulong ReadBits(uint count, out uint value)
+        public virtual ulong ReadBits(uint count, out uint value)
         {
             if (count > 32)
                 throw new ArgumentException("'count' cannot be greater than 32", nameof(count));
@@ -105,13 +116,13 @@ namespace SharpMP4.Common
             return originalCount;
         }
 
-        public uint ReadBits(uint count)
+        public virtual uint ReadBits(uint count)
         {
             ReadBits(count, out uint value);
             return value;
         }
 
-        public ulong ReadBits(uint count, out ulong value)
+        public virtual ulong ReadBits(uint count, out ulong value)
         {
             if (count > 64)
                 throw new ArgumentException("'count' cannot be greater than 64", nameof(count));
@@ -136,13 +147,13 @@ namespace SharpMP4.Common
             return originalCount;
         }
 
-        public ulong ReadBits(ulong count)
+        public virtual ulong ReadBits(ulong count)
         {
             ReadBits((uint)count, out ulong value);
             return value;
         }
 
-        public ulong WriteBits(uint count, ulong value)
+        public virtual ulong WriteBits(uint count, ulong value)
         {
             if (count > 64)
                 throw new ArgumentException("'count' cannot be greater than 64", nameof(count));
@@ -159,7 +170,7 @@ namespace SharpMP4.Common
             return originalCount;
         }
 
-        public uint WriteBits(uint count, uint value)
+        public virtual uint WriteBits(uint count, uint value)
         {
             if (count > 32)
                 throw new ArgumentException("'count' cannot be greater than 32", nameof(count));

--- a/src/SharpMP4Common/RbspBitstream.cs
+++ b/src/SharpMP4Common/RbspBitstream.cs
@@ -1,0 +1,153 @@
+﻿using System.IO;
+
+namespace SharpMP4.Common
+{
+    public class RbspBitstream
+    {
+        private bool _skipStartCodes = true;
+        private bool _insertStartCodes = true;
+        private int _prevByte = -1;
+        private int _prevPrevByte = -1;
+        private long _lastMarkPos;
+        protected long _bitsPosition;
+        protected long _currentBytePosition = -1;
+        protected byte _currentByte;
+
+        protected Stream _stream;
+
+        public RbspBitstream(Stream stream)
+        {
+            this._stream = stream;
+        }
+
+        public Stream BaseStream
+        {
+            get => _stream;
+            set => _stream = value;
+        }
+
+        public long BitsPosition
+        {
+            get => _bitsPosition;
+            set => _bitsPosition = value;
+        }
+
+        public byte CurrentByte
+        {
+            get => _currentByte;
+            set => _currentByte = value;
+        }
+
+        public bool SkipStartCodes
+        {
+            get => _skipStartCodes;
+            set => _skipStartCodes = value;
+        }
+
+        public bool InsertStartCodes
+        {
+            get => _insertStartCodes;
+            set => _insertStartCodes = value;
+        }
+
+        public virtual void CopyState(RbspBitstream bitstream)
+        {
+            this._prevByte = bitstream._prevByte;
+            this._prevPrevByte = bitstream._prevPrevByte;
+            this._currentByte = bitstream._currentByte;
+            this.InsertStartCodes = bitstream.InsertStartCodes;
+            this.SkipStartCodes = bitstream.SkipStartCodes;
+            this._bitsPosition = bitstream._bitsPosition;
+            this._currentBytePosition = bitstream._currentBytePosition;
+            this._lastMarkPos = bitstream._lastMarkPos;
+        }
+
+        public virtual void Mark() => this._lastMarkPos = this._bitsPosition;
+        public virtual long GetBitsSinceMark() => this._bitsPosition - this._lastMarkPos;
+
+        public int ReadBit()
+        {
+            long bytePos = _bitsPosition / 8;
+
+            if (_currentBytePosition != bytePos)
+            {
+                int bb = _stream.ReadByte();
+                if (bb == -1)
+                {
+                    return -1;
+                }
+
+                byte b = (byte)bb;
+
+                if (_skipStartCodes && _prevByte == 0 && _currentByte == 0 && b == 0x03)
+                {
+                    _prevByte = b;
+                    bb = _stream.ReadByte();
+
+                    if (bb == -1)
+                    {
+                        return -1;
+                    }
+
+                    b = (byte)bb;
+                    _bitsPosition += 8;
+                    _lastMarkPos += 8;
+                    bytePos++;
+                }
+                else
+                {
+                    _prevByte = _currentByte;
+                }
+
+                _currentByte = b;
+                _currentBytePosition = bytePos;
+            }
+
+            long posInByte = 7 - _bitsPosition % 8;
+            int bit = _currentByte >> (int)posInByte & 1;
+            _bitsPosition++;
+
+            return bit;
+        }
+
+        public void WriteBit(int value)
+        {
+            int posInByte = 7 - (int)_bitsPosition % 8;
+            int bit = (value & 1) << posInByte;
+            _currentByte = (byte)(_currentByte | bit);
+            ++_bitsPosition;
+
+            long bytePos = _bitsPosition / 8;
+            if (_currentBytePosition != bytePos)
+            {
+                if (_currentBytePosition < 0)
+                {
+                    _currentBytePosition = bytePos;
+                    return;
+                }
+
+                if (_skipStartCodes)
+                {
+                    if (_prevByte == 0x00 &&
+                        _prevPrevByte == 0x00 &&
+                        (_currentByte is 0x00 or 0x01 or 0x02 or 0x03))
+                    {
+                        _stream.WriteByte(0x03);
+                        bytePos++;
+                        _bitsPosition += 8;
+                        _lastMarkPos += 8;
+                        _prevByte = 0x03;
+                    }
+                }
+
+                _stream.WriteByte(_currentByte);
+                _currentBytePosition = bytePos;
+
+                _prevPrevByte = _prevByte;
+                _prevByte = _currentByte;
+
+                _currentByte = 0;
+            }
+        }
+    }
+}

--- a/src/SharpMP4Common/RbspBitstream.cs
+++ b/src/SharpMP4Common/RbspBitstream.cs
@@ -126,7 +126,7 @@ namespace SharpMP4.Common
                     return;
                 }
 
-                if (_skipStartCodes)
+                if (_insertStartCodes)
                 {
                     if (_prevByte == 0x00 &&
                         _prevPrevByte == 0x00 &&

--- a/src/SharpMP4Common/RbspBitstream.cs
+++ b/src/SharpMP4Common/RbspBitstream.cs
@@ -4,8 +4,8 @@ namespace SharpMP4.Common
 {
     public class RbspBitstream
     {
-        private bool _skipStartCodes = true;
-        private bool _insertStartCodes = true;
+        private bool _skipPreventionBytes = true;
+        private bool _insertPreventionBytes = true;
         private int _prevByte = -1;
         private int _prevPrevByte = -1;
         private long _lastMarkPos;
@@ -38,16 +38,16 @@ namespace SharpMP4.Common
             set => _currentByte = value;
         }
 
-        public bool SkipStartCodes
+        public bool SkipPreventionBytes
         {
-            get => _skipStartCodes;
-            set => _skipStartCodes = value;
+            get => _skipPreventionBytes;
+            set => _skipPreventionBytes = value;
         }
 
-        public bool InsertStartCodes
+        public bool InsertPreventionBytes
         {
-            get => _insertStartCodes;
-            set => _insertStartCodes = value;
+            get => _insertPreventionBytes;
+            set => _insertPreventionBytes = value;
         }
 
         public virtual void CopyState(RbspBitstream bitstream)
@@ -55,8 +55,8 @@ namespace SharpMP4.Common
             this._prevByte = bitstream._prevByte;
             this._prevPrevByte = bitstream._prevPrevByte;
             this._currentByte = bitstream._currentByte;
-            this.InsertStartCodes = bitstream.InsertStartCodes;
-            this.SkipStartCodes = bitstream.SkipStartCodes;
+            this.InsertPreventionBytes = bitstream.InsertPreventionBytes;
+            this.SkipPreventionBytes = bitstream.SkipPreventionBytes;
             this._bitsPosition = bitstream._bitsPosition;
             this._currentBytePosition = bitstream._currentBytePosition;
             this._lastMarkPos = bitstream._lastMarkPos;
@@ -79,7 +79,7 @@ namespace SharpMP4.Common
 
                 byte b = (byte)bb;
 
-                if (_skipStartCodes && _prevByte == 0 && _currentByte == 0 && b == 0x03)
+                if (_skipPreventionBytes && _prevByte == 0 && _currentByte == 0 && b == 0x03)
                 {
                     _prevByte = b;
                     bb = _stream.ReadByte();
@@ -126,7 +126,7 @@ namespace SharpMP4.Common
                     return;
                 }
 
-                if (_insertStartCodes)
+                if (_insertPreventionBytes)
                 {
                     if (_prevByte == 0x00 &&
                         _prevPrevByte == 0x00 &&

--- a/src/SharpMP4Common/SharpMP4Common.csproj
+++ b/src/SharpMP4Common/SharpMP4Common.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>SharpMP4.Common</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR moves all bit-stream related logic inside `IsoStream` and `AomStream` into a single, unified class named `Bitstream`, and `ItuStream` into `RbspBitstream`. New types are located inside the `SharpMP4.Common` namespace. All these classes now have a `Bitstream` property, as well as a constructor overload to use a bitstream directly or create one with a `Stream`.

The `Bitstream` class provides `ReadBit`, `WriteBit`, `ReadBits`, `WriteBits`, `ReadByte` and `WriteByte` methods. It also exposes internal state as a public API (bits position, stream, current byte, etc), allowing users to tell SharpMP4 where to begin reading, and then grab the state and continue reading. For example, in H.264, once a `slice_header()` finished parsing, one can grab the bit-stream state and adapt to their custom bit-stream implementation to read entropy-coded data, or use the bit-stream class directly.

`RbspBitstream` is a special variant that allows optional, automatic handling of emulation prevention bytes inside RBSP data, and is meant to be used by `ItuStream`. Properties `SkipPreventionBytes` and `InsertPreventionBytes` (both of which are true by default) allow optional skipping and insertion of emulation prevention bytes on read and write, respectfully. `RbspBitstream` also provides a way to mark current bits position.

I was able to successfully adapt all bit-streams into these two types. `SampleVideoParser` does not seem to fail with unhandled exceptions.

This PR does not involve breaking changes. New constructor overloads were added while keeping previous constructors.

I can also:
- Add extension methods for Exponential Golomb handling
- Add an `IBitstream` interface and make both types implement it
- Move into the `SharpMP4.Common.Bitstreams` namespace
- Change the wording "Bitstream" into "BitStream"

This PR also addresses one potential bug - previously, the bit position was stored as an `int`, which only represents numbers up to ~2 billion. That means once it tried to parse video data beyond 256MB, it would simply wrap around back to 0. This is now changed - bit position is stored as `long`, which can represent up to 1 exabyte of data - basically infinite, as no consumer device (let alone video data) has this much data. However, `AomStream`'s `GetPosition()` method still returns int. I'd have to modify source generators to continuously cast to a `long`. I've left a TODO just in case.
